### PR TITLE
Fix Python syntax error

### DIFF
--- a/reinforcement/tensorflow/minigo/yomi/simple_eval.py
+++ b/reinforcement/tensorflow/minigo/yomi/simple_eval.py
@@ -37,7 +37,7 @@ def run():
     # Now that we have all the models, we can pit them against eachother them.
     # For now, just pick the last two.
     p1, p2 = None, None
-    if len(models) = 0:
+    if len(models) == 0:
         sys.stderr.write('No models found!\n')
         sys.exit(1)
     elif len(models) == 1:


### PR DESCRIPTION
flake8 testing of https://github.com/mlperf/reference on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./reinforcement/tensorflow/minigo/goparams.py:50:12: F821 undefined name 'BASE_DIR'
BASE_DIR = BASE_DIR.replace('$HOME', HOME)
           ^
./reinforcement/tensorflow/minigo/yomi/simple_eval.py:40:20: E999 SyntaxError: invalid syntax
    if len(models) = 0:
                   ^
./sentiment_analysis/paddle/train.py:149:40: E999 TabError: inconsistent use of tabs and spaces in indentation
		train_loss_set.append(float(cost_val))
                                       ^
./speech_recognition/pytorch/train.py:74:79: E999 SyntaxError: invalid syntax
      print "ERROR: GRU does not currently support activations other than tanh"
                                                                              ^
./translation/data_download.py:343:15: F821 undefined name 'six'
  for k, v in six.iteritems(dictionary):
              ^
./translation/tensorflow/transformer/utils/tokenizer.py:206:31: F821 undefined name 'unicode'
    return s if isinstance(s, unicode) else s.decode("utf-8")
                              ^
./translation/tensorflow/transformer/utils/tokenizer.py:214:47: F821 undefined name 'unicode'
    return s.encode("utf-8") if isinstance(s, unicode) else s
                                              ^
3     E999 SyntaxError: invalid syntax
4     F821 undefined name 'BASE_DIR'
7
```