### PR TITLE
Fix run_an_time.sh for recommendation built from source

### DIFF
--- a/recommendation/pytorch/run_and_time.sh
+++ b/recommendation/pytorch/run_and_time.sh
@@ -4,7 +4,7 @@
 #   run_and_time.sh <random seed 1-5>
 
 THRESHOLD=0.9562
-BASEDIR=$(dirname "$0")
+BASEDIR=$(dirname -- "$0")
 
 # start timing
 start=$(date +%s)


### PR DESCRIPTION
I confirmed the Docker and from source instructions work with complete runs to the threshold. This should have no impact on performance.