### PR TITLE
Add more negative examples

### DIFF
--- a/recommendation/pytorch/Dockerfile
+++ b/recommendation/pytorch/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir github
 WORKDIR /mlperf/github
 RUN git clone --recursive https://github.com/pytorch/pytorch
 WORKDIR /mlperf/github/pytorch
-RUN git checkout e83dd71
+RUN git checkout v0.4.0
 RUN git submodule update --init
 RUN python setup.py clean
 RUN python setup.py install

--- a/recommendation/pytorch/README.md
+++ b/recommendation/pytorch/README.md
@@ -97,7 +97,7 @@ Positive training examples are all but the last item each user rated.
 Negative training examples are randomly selected from the unrated items for each user.
 
 The last item each user rated is used as a positive example in the test set.
-A fixed set of 100 unrated items are also selected to calculate hit rate at 10 for predicting the test item.
+A fixed set of 999 unrated items are also selected to calculate hit rate at 10 for predicting the test item.
 
 ### Training data order
 Data is traversed randomly with 4 negative examples selected on average for every positive example.
@@ -111,10 +111,10 @@ The author's original code is available at [hexiangnan/neural_collaborative_filt
 
 # 5. Quality
 ### Quality metric
-Hit rate at 10 (HR@10) with 100 negative items.
+Hit rate at 10 (HR@10) with 999 negative items.
 
 ### Quality target
-HR@10: 0.9562
+HR@10: 0.6289
 
 ### Evaluation frequency
 After every epoch through the training data.

--- a/recommendation/pytorch/convert.py
+++ b/recommendation/pytorch/convert.py
@@ -4,8 +4,12 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
+from tqdm import tqdm
 
 from load import implicit_load
+
+
+MIN_RATINGS = 20
 
 
 USER_COLUMN = 'user_id'
@@ -35,10 +39,13 @@ def main():
     args = parse_args()
     np.random.seed(args.seed)
 
+    print("Loading raw data from {}".format(args.path))
     df = implicit_load(args.path, sort=False)
+    print("Filtering out users with less than {} ratings".format(MIN_RATINGS))
     grouped = df.groupby(USER_COLUMN)
-    df = grouped.filter(lambda x: len(x) >= 20)
+    df = grouped.filter(lambda x: len(x) >= MIN_RATINGS)
 
+    print("Mapping original user and item IDs to new sequential IDs")
     original_users = df[USER_COLUMN].unique()
     original_items = df[ITEM_COLUMN].unique()
 
@@ -51,17 +58,20 @@ def main():
     assert df[USER_COLUMN].max() == len(original_users) - 1
     assert df[ITEM_COLUMN].max() == len(original_items) - 1
 
+    print("Creating list of items for each user")
     # Need to sort before popping to get last item
     df.sort_values(by='timestamp', inplace=True)
     all_ratings = set(zip(df[USER_COLUMN], df[ITEM_COLUMN]))
     user_to_items = defaultdict(list)
-    for row in df.itertuples():
+    for row in tqdm(df.itertuples(), desc='Ratings', total=len(df)):
         user_to_items[getattr(row, USER_COLUMN)].append(getattr(row, ITEM_COLUMN))  # noqa: E501
 
     test_ratings = []
     test_negs = []
     all_items = set(range(len(original_items)))
-    for user in range(len(original_users)):
+    print("Generating {} negative samples for each user"
+          .format(args.negatives))
+    for user in tqdm(range(len(original_users)), desc='Users', total=len(original_users)):  # noqa: E501
         test_item = user_to_items[user].pop()
 
         all_ratings.remove((user, test_item))
@@ -71,7 +81,7 @@ def main():
         test_ratings.append((user, test_item))
         test_negs.append(list(np.random.choice(all_negs, args.negatives)))
 
-    # serialize
+    print("Saving train and test CSV files to {}".format(args.output))
     df_train_ratings = pd.DataFrame(list(all_ratings))
     df_train_ratings['fake_rating'] = 1
     df_train_ratings.to_csv(os.path.join(args.output, TRAIN_RATINGS_FILENAME),

--- a/recommendation/pytorch/convert.py
+++ b/recommendation/pytorch/convert.py
@@ -11,7 +11,6 @@ from load import implicit_load
 USER_COLUMN = 'user_id'
 ITEM_COLUMN = 'item_id'
 
-NUMBER_NEGATIVES = 100
 
 TRAIN_RATINGS_FILENAME = 'train-ratings.csv'
 TEST_RATINGS_FILENAME = 'test-ratings.csv'
@@ -20,15 +19,21 @@ TEST_NEG_FILENAME = 'test-negative.csv'
 
 def parse_args():
     parser = ArgumentParser()
-    parser.add_argument('path', type=str)
-    parser.add_argument('output', type=str)
+    parser.add_argument('path', type=str,
+                        help='Path to reviews CSV file from MovieLens')
+    parser.add_argument('output', type=str,
+                        help='Output directory for train and test CSV files')
+    parser.add_argument('-n', '--negatives', type=int, default=999,
+                        help='Number of negative samples for each positive'
+                             'test example')
+    parser.add_argument('-s', '--seed', type=int, default=0,
+                        help='Random seed to reproduce same negative samples')
     return parser.parse_args()
 
 
 def main():
-    # TODO: Add random seed as parameter
-    np.random.seed(0)
     args = parse_args()
+    np.random.seed(args.seed)
 
     df = implicit_load(args.path, sort=False)
     grouped = df.groupby(USER_COLUMN)
@@ -64,7 +69,7 @@ def main():
         all_negs = sorted(list(all_negs))  # determinism
 
         test_ratings.append((user, test_item))
-        test_negs.append(list(np.random.choice(all_negs, NUMBER_NEGATIVES)))
+        test_negs.append(list(np.random.choice(all_negs, args.negatives)))
 
     # serialize
     df_train_ratings = pd.DataFrame(list(all_ratings))

--- a/recommendation/pytorch/dataset.py
+++ b/recommendation/pytorch/dataset.py
@@ -17,8 +17,8 @@ class CFTrainDataset(torch.utils.data.dataset.Dataset):
             return [int(tmp[0]), int(tmp[1]), float(tmp[2]) > 0]
         # these files are a few hundred megs tops
         # TODO: be unlazy? use pandas?
-        lines = open(train_fname, 'r').readlines()[1:]
-        data = list(map(process_line, lines))
+        with open(train_fname, 'r') as file:
+            data = list(map(process_line, file))
         self.nb_users = max(data, key=lambda x: x[0])[0] + 1
         self.nb_items = max(data, key=lambda x: x[1])[1] + 1
 

--- a/recommendation/pytorch/ncf.py
+++ b/recommendation/pytorch/ncf.py
@@ -96,6 +96,10 @@ def eval_one(rating, items, model, K, use_cuda=True):
 
 def val_epoch(model, ratings, negs, K, use_cuda=True, output=None, epoch=None,
               processes=1):
+    if epoch is None:
+        print("Initial evaluation")
+    else:
+        print("Epoch {} evaluation".format(epoch))
     start = datetime.now()
     model.eval()
     if processes > 1:
@@ -150,7 +154,7 @@ def main():
 
     t1 = time.time()
     # Load Data
-    # TODO: Reading CSVs is slow. Could use HDF or Apache Arrow
+    print('Loading data')
     train_dataset = CFTrainDataset(
         os.path.join(args.data, TRAIN_RATINGS_FILENAME), args.negative_samples)
     train_dataloader = torch.utils.data.DataLoader(

--- a/recommendation/pytorch/ncf.py
+++ b/recommendation/pytorch/ncf.py
@@ -2,6 +2,7 @@ import os
 import heapq
 import math
 import time
+from functools import partial
 from datetime import datetime
 from collections import OrderedDict
 from argparse import ArgumentParser
@@ -10,6 +11,7 @@ import tqdm
 import numpy as np
 import torch
 import torch.nn as nn
+from torch import multiprocessing as mp
 
 import utils
 from neumf import NeuMF
@@ -44,15 +46,14 @@ def parse_args():
                         help='manually set random seed for torch')
     parser.add_argument('--threshold', '-t', type=float,
                         help='stop training early at threshold')
+    parser.add_argument('--processes', '-p', type=int, default=1,
+                        help='Number of processes for evaluating model')
     return parser.parse_args()
 
 
 def predict(model, users, items, batch_size=1024, use_cuda=True):
     batches = [(users[i:i + batch_size], items[i:i + batch_size])
                for i in range(0, len(users), batch_size)]
-    model.eval()
-    if use_cuda:
-        model.cuda()
     preds = []
     for user, item in batches:
         def proc(x):
@@ -67,38 +68,48 @@ def predict(model, users, items, batch_size=1024, use_cuda=True):
     return preds
 
 
-def _calculate_hit(ranked, gt_item):
-    return int(gt_item in ranked)
+def _calculate_hit(ranked, test_item):
+    return int(test_item in ranked)
 
 
-def _calculate_ndcg(ranked, gt_item):
+def _calculate_ndcg(ranked, test_item):
     for i, item in enumerate(ranked):
-        if item == gt_item:
+        if item == test_item:
             return math.log(2) / math.log(i + 2)
     return 0.
 
 
 def eval_one(rating, items, model, K, use_cuda=True):
-    u = rating[0]
-    gt_item = rating[1]
-    items.append(gt_item)
-    users = np.full(len(items), u, dtype=np.int64)
+    user = rating[0]
+    test_item = rating[1]
+    items.append(test_item)
+    users = [user] * len(items)
     predictions = predict(model, users, items, use_cuda=use_cuda)
-    map_item_score = {item: pred for item, pred in zip(items, predictions)}
 
+    map_item_score = {item: pred for item, pred in zip(items, predictions)}
     ranked = heapq.nlargest(K, map_item_score, key=map_item_score.get)
-    hit = _calculate_hit(ranked, gt_item)
-    ndcg = _calculate_ndcg(ranked, gt_item)
+
+    hit = _calculate_hit(ranked, test_item)
+    ndcg = _calculate_ndcg(ranked, test_item)
     return hit, ndcg
 
 
-def val_epoch(model, ratings, negs, K, use_cuda=True, output=None, epoch=None):
+def val_epoch(model, ratings, negs, K, use_cuda=True, output=None, epoch=None,
+              processes=1):
     start = datetime.now()
-    hits, ndcgs = [], []
-    for rating, items in zip(ratings, negs):
-        hit, ndcg = eval_one(rating, items, model, K, use_cuda=use_cuda)
-        hits.append(hit)
-        ndcgs.append(ndcg)
+    model.eval()
+    if processes > 1:
+        context = mp.get_context('spawn')
+        _eval_one = partial(eval_one, model=model, K=K, use_cuda=use_cuda)
+        with context.Pool(processes=processes) as workers:
+            hits_and_ndcg = workers.starmap(_eval_one, zip(ratings, negs))
+        hits, ndcgs = zip(*hits_and_ndcg)
+    else:
+        hits, ndcgs = [], []
+        for rating, items in zip(ratings, negs):
+            hit, ndcg = eval_one(rating, items, model, K, use_cuda=use_cuda)
+            hits.append(hit)
+            ndcgs.append(ndcg)
 
     hits = np.array(hits, dtype=np.float32)
     ndcgs = np.array(ndcgs, dtype=np.float32)
@@ -178,7 +189,7 @@ def main():
 
     # Calculate initial Hit Ratio and NDCG
     hits, ndcgs = val_epoch(model, test_ratings, test_negs, args.topk,
-                            use_cuda=use_cuda)
+                            use_cuda=use_cuda, processes=args.processes)
     print('Initial HR@{K} = {hit_rate:.4f}, NDCG@{K} = {ndcg:.4f}'
           .format(K=args.topk, hit_rate=np.mean(hits), ndcg=np.mean(ndcgs)))
     for epoch in range(args.epochs):
@@ -213,7 +224,7 @@ def main():
         begin = time.time()
         hits, ndcgs = val_epoch(model, test_ratings, test_negs, args.topk,
                                 use_cuda=use_cuda, output=valid_results_file,
-                                epoch=epoch)
+                                epoch=epoch, processes=args.processes)
         val_time = time.time() - begin
         print('Epoch {epoch}: HR@{K} = {hit_rate:.4f}, NDCG@{K} = {ndcg:.4f},'
               ' train_time = {train_time:.2f}, val_time = {val_time:.2f}'

--- a/recommendation/pytorch/run_and_time.sh
+++ b/recommendation/pytorch/run_and_time.sh
@@ -3,7 +3,7 @@
 # to use the script:
 #   run_and_time.sh <random seed 1-5>
 
-THRESHOLD=0.9562
+THRESHOLD=0.6289
 BASEDIR=$(dirname -- "$0")
 
 # start timing
@@ -19,15 +19,15 @@ if unzip ml-20m.zip
 then
     echo "Start processing ml-20m/ratings.csv"
     t0=$(date +%s)
-	python $BASEDIR/convert.py ml-20m/ratings.csv ml-20m
+	python $BASEDIR/convert.py ml-20m/ratings.csv ml-20m --negatives 999
     t1=$(date +%s)
 	delta=$(( $t1 - $t0 ))
     echo "Finish processing ml-20m/ratings.csv in $delta seconds"
 
     echo "Start training"
     t0=$(date +%s)
-	python $BASEDIR/ncf.py ml-20m -l 0.0005 -b 16384 --layers 256 128 64 -f 64 \
-		--seed $seed --threshold $THRESHOLD
+	python $BASEDIR/ncf.py ml-20m -l 0.0005 -b 2048 --layers 256 128 64 -f 64 \
+		--seed $seed --threshold $THRESHOLD --processes 10
     t1=$(date +%s)
 	delta=$(( $t1 - $t0 ))
     echo "Finish training in $delta seconds"


### PR DESCRIPTION
This pull request addresses [mlperf/policies#14](https://github.com/mlperf/policies/issues/14) by increasing the number of negative samples from 100 to 999 for the recommendation benchmark and updating the threshold accordingly. The new threshold is a hit rate of 0.6289 at 10, which is based on the lowest hit rate achieved by the 5 random seeds:

```
seed
1    0.629786
2    0.633101
3    0.632241
4    0.628985
5    0.630992
Name: hit_rate, dtype: float64
```

[Here](https://github.com/mlperf/reference/files/2112584/n999_timing_output.txt) is the output using the new threshold with the 5 seeds.

Calculating validation accuracy was also improved to parallelize across CPUs, decreasing the validation time per epoch from ~90 seconds to ~53 seconds. Batch size also changed based on hyperparameter tuning from 16384 to 2048. This increased per epoch training time from ~190 seconds to ~350 seconds. Total end-to-end training time now ranged from 3960 seconds to 4772 with a median, mean, and standard deviation of 4361, 4338.4, and 261.74 respectively.
  