### PR TITLE
Added scipy and pandas to requirements.txt in /reference/recommendation

### DIFF
--- a/recommendation/pytorch/requirements.txt
+++ b/recommendation/pytorch/requirements.txt
@@ -1,1 +1,3 @@
 tqdm==4.20.0
+scipy
+pandas


### PR DESCRIPTION
The pytorch implementation of the recommendation benchmark requires scipy and pandas.