### PR TITLE
Fix random seed in workers and add 1 more layer in the MLP

### DIFF
--- a/recommendation/pytorch/README.md
+++ b/recommendation/pytorch/README.md
@@ -114,7 +114,7 @@ The author's original code is available at [hexiangnan/neural_collaborative_filt
 Hit rate at 10 (HR@10) with 999 negative items.
 
 ### Quality target
-HR@10: 0.6289
+HR@10: 0.635
 
 ### Evaluation frequency
 After every epoch through the training data.

--- a/recommendation/pytorch/dataset.py
+++ b/recommendation/pytorch/dataset.py
@@ -13,10 +13,7 @@ class CFTrainDataset(torch.utils.data.dataset.Dataset):
     def _load_train_matrix(self, train_fname):
         def process_line(line):
             tmp = line.split('\t')
-            # user, item, rating???
             return [int(tmp[0]), int(tmp[1]), float(tmp[2]) > 0]
-        # these files are a few hundred megs tops
-        # TODO: be unlazy? use pandas?
         with open(train_fname, 'r') as file:
             data = list(map(process_line, file))
         self.nb_users = max(data, key=lambda x: x[0])[0] + 1
@@ -38,9 +35,9 @@ class CFTrainDataset(torch.utils.data.dataset.Dataset):
         else:
             idx = idx // (self.nb_neg + 1)
             u = self.data[idx][0]
-            j = np.random.randint(self.nb_items)
+            j = torch.LongTensor(1).random_(0, self.nb_items).item()
             while (u, j) in self.mat:
-                j = np.random.randint(self.nb_items)
+                j = torch.LongTensor(1).random_(0, self.nb_items).item()
             return u, j, np.zeros(1, dtype=np.float32)
 
 

--- a/recommendation/pytorch/dataset.py
+++ b/recommendation/pytorch/dataset.py
@@ -45,15 +45,13 @@ def load_test_ratings(fname):
     def process_line(line):
         tmp = map(int, line.split('\t')[0:2])
         return list(tmp)
-    lines = open(fname, 'r').readlines()
-    ratings = map(process_line, lines)
+    ratings = map(process_line, open(fname, 'r'))
     return list(ratings)
 
 
 def load_test_negs(fname):
     def process_line(line):
-        tmp = map(int, line.split('\t')[1:])
+        tmp = map(int, line.split('\t'))
         return list(tmp)
-    lines = open(fname, 'r').readlines()
-    negs = map(process_line, lines)
+    negs = map(process_line, open(fname, 'r'))
     return list(negs)

--- a/recommendation/pytorch/ncf.py
+++ b/recommendation/pytorch/ncf.py
@@ -48,6 +48,8 @@ def parse_args():
                         help='stop training early at threshold')
     parser.add_argument('--processes', '-p', type=int, default=1,
                         help='Number of processes for evaluating model')
+    parser.add_argument('--workers', '-w', type=int, default=8,
+                        help='Number of workers for training DataLoader')
     return parser.parse_args()
 
 
@@ -159,7 +161,7 @@ def main():
         os.path.join(args.data, TRAIN_RATINGS_FILENAME), args.negative_samples)
     train_dataloader = torch.utils.data.DataLoader(
             dataset=train_dataset, batch_size=args.batch_size, shuffle=True,
-            num_workers=8, pin_memory=True)
+            num_workers=args.workers, pin_memory=True)
     test_ratings = load_test_ratings(os.path.join(args.data, TEST_RATINGS_FILENAME))  # noqa: E501
     test_negs = load_test_negs(os.path.join(args.data, TEST_NEG_FILENAME))
     nb_users, nb_items = train_dataset.nb_users, train_dataset.nb_items

--- a/recommendation/pytorch/run_and_time.sh
+++ b/recommendation/pytorch/run_and_time.sh
@@ -26,7 +26,7 @@ then
 
     echo "Start training"
     t0=$(date +%s)
-	python $BASEDIR/ncf.py ml-20m -l 0.0005 -b 2048 --layers 256 128 64 -f 64 \
+	python $BASEDIR/ncf.py ml-20m -l 0.0005 -b 2048 --layers 256 256 128 64 -f 64 \
 		--seed $seed --threshold $THRESHOLD --processes 10
     t1=$(date +%s)
 	delta=$(( $t1 - $t0 ))

--- a/recommendation/pytorch/run_and_time.sh
+++ b/recommendation/pytorch/run_and_time.sh
@@ -3,7 +3,7 @@
 # to use the script:
 #   run_and_time.sh <random seed 1-5>
 
-THRESHOLD=0.6289
+THRESHOLD=0.635
 BASEDIR=$(dirname -- "$0")
 
 # start timing


### PR DESCRIPTION
This pull request addresses a bug with the random seed in DataLoader workers. Rather than using numpy to generate indices for the random negative training examples, the code now uses torch, which correctly sets a different random seed for each worker. Previously, increasing the number of workers for the DataLoader dramatically decreased the final quality.

Additionally, the MLP part of the model includes an additional Dense layer to match the default of three from the [original paper](http://delivery.acm.org/10.1145/3060000/3052569/p173-he.pdf?ip=171.64.70.182&id=3052569&acc=ACTIVE%20SERVICE&key=AA86BE8B6928DDC7%2E0AF80552DEC4BA76%2E4D4702B0C3E38B35%2E4D4702B0C3E38B35&__acm__=1531261116_fc0ef27a681d1faed305ada95d675bda): 

> Without special mention, we employed three hidden layers for MLP; for example, if the size of predictive factors is 8, then the architecture of the neural CF layers is 32 → 16 → 8, and the embedding size is 16.

Together these changes slightly improve performance, so the threshold is raised from 0.6289 to 0.635 based on the lowest run from the 5 random seeds:

```
seed
1    0.636112
2    0.639693
3    0.636270
4    0.636227
5    0.635801
Name: hit_rate, dtype: float64
```

The other hyper parameters are the same, and training time is similar to [PR#68](https://github.com/mlperf/reference/pull/68)
